### PR TITLE
Chore/unify transaction result information

### DIFF
--- a/src/transbank_webpay.php
+++ b/src/transbank_webpay.php
@@ -283,6 +283,12 @@ class plgVmPaymentTransbank_Webpay extends vmPSPlugin {
         $app = JFactory::getApplication();
         $app->enqueueMessage('Pago exitoso', 'message');
 
+        if ($result->detailOutput->responseCode == 0) {
+            $transactionResponse = "Transacci&oacute;n Aprobada";
+        } else {
+            $transactionResponse = "Transacci&oacute;n Rechazada";
+        }
+
         if($result->detailOutput->paymentTypeCode == "SI" || $result->detailOutput->paymentTypeCode == "S2" ||
             $result->detailOutput->paymentTypeCode == "NC" || $result->detailOutput->paymentTypeCode == "VC" ) {
             $tipoCuotas = $this->paymentTypeCodearray[$result->detailOutput->paymentTypeCode];
@@ -290,17 +296,26 @@ class plgVmPaymentTransbank_Webpay extends vmPSPlugin {
             $tipoCuotas = "Sin cuotas";
         }
 
+        if($result->detailOutput->paymentTypeCode == "VD"){
+            $paymentType = "Débito";
+        } else {
+            $paymentType = "Crédito";
+        }
+
 		$message = "<h2>Detalles del pago con Webpay</h2>
         <p>
             <br>
-            <b>Respuesta de la Transacci&oacute;n: </b>{$result->detailOutput->responseCode}<br>
+            <b>Respuesta de la Transacci&oacute;n: </b>{$transactionResponse}<br>
+            <b>C&oacute;digo de la Transacci&oacute;n: </b>{$result->detailOutput->responseCode}<br>
             <b>Monto:</b> $ {$result->detailOutput->amount}<br>
             <b>Order de Compra: </b> {$result->detailOutput->buyOrder}<br>
             <b>Fecha de la Transacci&oacute;n: </b>".date('d-m-Y', strtotime($result->transactionDate))."<br>
             <b>Hora de la Transacci&oacute;n: </b>".date('H:i:s', strtotime($result->transactionDate))."<br>
             <b>Tarjeta: </b>************{$result->cardDetail->cardNumber}<br>
-            <b>C&oacute;digo de autorizacion: </b>{$result->detailOutput->authorizationCode}<br>
-            <b>N&uacute;mero de cuotas: </b>{$tipoCuotas}
+            <b>C&oacute;digo de autorizaci&oacute;n: </b>{$result->detailOutput->authorizationCode}<br>
+            <b>Tipo de Pago: </b>{$paymentType}<br>
+            <b>Tipo de Cuotas: </b>{$tipoCuotas}<br>
+            <b>N&uacute;mero de cuotas: </b>{$result->detailOutput->sharesNumber}
         </p>";
         return $message;
     }


### PR DESCRIPTION
Across all plugins the information being shown wasn't the same.

Now the information shown in the transaction success information screen is the same for all plugins.

Disclaimer: The order of the information shown might not be the same